### PR TITLE
Fix wrong XPath interpretation

### DIFF
--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -187,13 +187,13 @@ export const createCursor = (page: Page, start: Vector = origin, performRandomMo
       actions.toggleRandomMove(false)
       let elem
       if (typeof selector === 'string') {
-        if (selector.includes('//')) {
+        if (selector.startsWith('//') || selector.startsWith('(//')) {
           if (options?.waitForSelector !== undefined) {
             await page.waitForXPath(selector, {
               timeout: options.waitForSelector
             })
           }
-          elem = await page.$x(selector)
+          [elem] = await page.$x(selector)
         } else {
           if (options?.waitForSelector !== undefined) {
             await page.waitForSelector(selector, {


### PR DESCRIPTION
If we use XPath for selector, the elementHandle is an array and the getElementBox method return a null value (elementHandle must be an Object, but an array is passed )   
Don't use includes() method for XPath checking. It causes problem when a css selector contains a double slash (ie : a[href="http://example.com"]) => in this case, the moveCursor method uses a waitForXpath instead of waitForSelector

Here is an example who didn't work before :
```javascript
const cursor = createCursor(page, await getRandomPagePoint(page), true);
await installMouseHelper(page); // this shows the trace
await page.goto('https://old.reddit.com', { waitUntil: 'networkidle0' });

/* Reddit tests for bug catch */
// const selector = '//a[@href="https://old.reddit.com/controversial/"]' /* Not working */
// const selector = 'a[href="https://old.reddit.com/controversial/"]' /* Not working */
// const selector = '(//a[@class="choice"])[3]' /* Not working */
// const selector = '//a[@class="login-required"]' /* Not working */
const selector = 'a[class="login-required"]' /* Working */
console.log('Waiting fo selector', selector)
if (selector.startsWith('//') || selector.startsWith('(//')) {
    await page.waitForXPath(selector, {timeout: selectorTimeout})
}
else {
    await page.waitForSelector(selector, {timeout: selectorTimeout})
}
console.log('Selector Found');

console.log('Before click')
await cursor.click(selector, { waitForMouse: 10000, waitForSelector: 10000, paddingPercentage: 20 });
console.log('After click')

```

