### PR TITLE
Move @types/bezier-js to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,10 +22,10 @@
     "lib/**/*"
   ],
   "dependencies": {
+    "@types/bezier-js": "4",
     "bezier-js": "^6"
   },
   "devDependencies": {
-    "@types/bezier-js": "4",
     "husky": "7",
     "puppeteer": "13",
     "ts-standard": "11",


### PR DESCRIPTION
This fixes https://github.com/Xetera/ghost-cursor/issues/41