### PR TITLE
Support puppeteer > v14 CDP client

### DIFF
--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -72,10 +72,14 @@ const getRandomBoxPoint = (
   }
 }
 
+// The function signature to access the internal CDP client changed in puppeteer 14.4.1
+const getCDPClient = (page: any) => typeof page._client === 'function' ? page._client() : page._client
+
 // Get a random point on a browser window
 export const getRandomPagePoint = async (page: Page): Promise<Vector> => {
   const targetId: string = page.target()._targetId
-  const window = await (page as any)._client.send(
+  const client = getCDPClient(page as any)
+  const window = await client.send(
     'Browser.getWindowForTarget',
     { targetId }
   )
@@ -98,7 +102,8 @@ const getElementBox = async (
   }
 
   try {
-    const quads = await (page as any)._client.send('DOM.getContentQuads', {
+    const client = getCDPClient(page as any)
+    const quads = await client.send('DOM.getContentQuads', {
       objectId: element._remoteObject.objectId
     })
     const elementBox = {

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -1,4 +1,4 @@
-import { ElementHandle, Page, BoundingBox } from 'puppeteer'
+import { ElementHandle, Page, BoundingBox, CDPSession } from 'puppeteer'
 import {
   Vector,
   bezierCurve,
@@ -73,13 +73,12 @@ const getRandomBoxPoint = (
 }
 
 // The function signature to access the internal CDP client changed in puppeteer 14.4.1
-const getCDPClient = (page: any) => typeof page._client === 'function' ? page._client() : page._client
+const getCDPClient = (page: any): CDPSession => typeof page._client === 'function' ? page._client() : page._client
 
 // Get a random point on a browser window
 export const getRandomPagePoint = async (page: Page): Promise<Vector> => {
   const targetId: string = page.target()._targetId
-  const client = getCDPClient(page as any)
-  const window = await client.send(
+  const window = await getCDPClient(page).send(
     'Browser.getWindowForTarget',
     { targetId }
   )
@@ -102,8 +101,7 @@ const getElementBox = async (
   }
 
   try {
-    const client = getCDPClient(page as any)
-    const quads = await client.send('DOM.getContentQuads', {
+    const quads = await getCDPClient(page).send('DOM.getContentQuads', {
       objectId: element._remoteObject.objectId
     })
     const elementBox = {
@@ -329,7 +327,7 @@ export const createCursor = (
         // Make sure the object is in view
         if (elem._remoteObject?.objectId !== undefined) {
           try {
-            await (page as any)._client.send('DOM.scrollIntoViewIfNeeded', {
+            await getCDPClient(page).send('DOM.scrollIntoViewIfNeeded', {
               objectId: elem._remoteObject.objectId
             })
           } catch (e) {


### PR DESCRIPTION
The function signature to access the internal CDP client changed in puppeteer 14.4.1

This PR updates the code to support both signatures.

For reference the similar changes we  implemented in the stealth plugin: https://github.com/berstend/puppeteer-extra/commit/abda7842fc4ac3b62ef7c2999a2307817a7ab3da

Note: I've used the GH editor for these changes and didn't do or test them in a local repo