### PR TITLE
Add clickCount functionality -> Update spoof.ts

### DIFF
--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -22,6 +22,7 @@ export interface MoveOptions extends BoxOptions {
 
 export interface ClickOptions extends MoveOptions {
   readonly waitForClick?: number
+  readonly clickCount?: number
 }
 
 export interface PathOptions {
@@ -279,7 +280,7 @@ export const createCursor = (
       }
 
       try {
-        await page.mouse.down()
+        await page.mouse.down({ clickCount: options?.clickCount ?? 1 })
         if (options?.waitForClick !== undefined) {
           await delay(options.waitForClick)
         }


### PR DESCRIPTION
This commit adds a clickCount parameter to the click() function, similar to puppeteer's

The use case for me is highlighting all the text in an input field before typing into it, such that typing overwrites any value already present

I do not believe the waitForClick parameter would function as expected when specified simultaneously with this new clickCount parameter, so I suspect some changes may be needed before merged.

One thought I had was simply using a for loop to perform up() and down() repeatedly, preserving the delay. However it doesn't seem to work, I am not sure why.

```
await page.mouse.down()
if (options?.waitForClick !== undefined) { await delay(options.waitForClick) }
if (options?.clickCount !== undefined) {
  for(var i = 0; i < options.clickCount-1; i++) {
    await page.mouse.down()
    if (options?.waitForClick !== undefined) { await delay(options.waitForClick) }
    await page.mouse.up()
  }
await page.mouse.up()
```

awesome project btw!
