### PR TITLE
Fix JS Memory heap out issue

### DIFF
--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -156,7 +156,7 @@ export function path (start: Vector, end: BoundingBox | Vector, optionsOrSpread?
 
   const defaultWidth = 100
   const minSteps = 25
-  const width = 'width' in end && end.width!=0  ? end.width : defaultWidth
+  const width = 'width' in end && end.width !== 0 ? end.width : defaultWidth
   const curve = bezierCurve(start, end, spreadOverride)
   const length = curve.length() * 0.8
 

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -156,7 +156,7 @@ export function path (start: Vector, end: BoundingBox | Vector, optionsOrSpread?
 
   const defaultWidth = 100
   const minSteps = 25
-  const width = 'width' in end ? end.width : defaultWidth
+  const width = 'width' in end && end.width!=0  ? end.width : defaultWidth
   const curve = bezierCurve(start, end, spreadOverride)
   const length = curve.length() * 0.8
 


### PR DESCRIPTION
When the width of the element is 0, the fitts calculation returns infinity and then it leads to the JS memory heap out and process termination. This PR solves the issue.

Related to issue #28 