### PR TITLE
feat: ability to associate timestamps with movements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import { path } from "ghost-cursor"
 const from = { x: 100, y: 100 }
 const to = { x: 600, y: 700 }
 
-const route = path(from, to, { showTimestamps: true })
+const route = path(from, to, { useTimestamps: true })
 
 /**
  * [
@@ -159,16 +159,16 @@ Installs a mouse helper on the page. Makes pointer visible. Use for debugging on
 
 Gets a random point on the browser window.
 
-#### `path(point: Vector, target: Vector, optionsOrSpread?: number | PathOptions): Vector[]`
+#### `path(point: Vector, target: Vector, options?: number | PathOptions): Vector[] | TimedVector[]`
 
 Generates a set of points for mouse movement between two coordinates.
 
 - **point:** Starting point of the movement.
 - **target:** Ending point of the movement.
-- **optionsOrSpread (optional):** Additional options for generating the path.
+- **options (optional):** Additional options for generating the path. Can also be a number which will set `spreadOverride`.
   - `spreadOverride (number):` Override the spread of the generated path.
   - `moveSpeed (number):` Speed of mouse movement. Default is random.
-  - `showTimestamps (boolean):` Generate timestamps for each point based on the trapezoidal rule.
+  - `useTimestamps (boolean):` Generate timestamps for each point based on the trapezoidal rule.
 
 ## How does it work
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ const route = path(from, to)
  */
 ```
 
+Generating movement data between 2 coordinates with timestamps.
+```js
+import { path } from "ghost-cursor"
+
+const from = { x: 100, y: 100 }
+const to = { x: 600, y: 700 }
+
+const routes = path(from, to, { showTimestamps: true })
+
+/**
+ * [
+ *   { x: 100, y: 100, timestamp: 1711850430643 },
+ *   { x: 114.78071695023473, y: 97.52340709495319, timestamp: 1711850430697 },
+ *   { x: 129.1362373468682, y: 96.60141853603243, timestamp: 1711850430749 },
+ *   { x: 143.09468422606352, y: 97.18676354029148, timestamp: 1711850430799 },
+ *   { x: 156.68418062398405, y: 99.23217132478408, timestamp: 1711850430848 },
+ *   ... and so on
+ * ]
+ */
+```
+
+
 Usage with puppeteer:
 
 ```js
@@ -126,7 +148,7 @@ Generates a set of points for mouse movement between two coordinates.
 - **optionsOrSpread (optional):** Additional options for generating the path.
   - `spreadOverride (number):` Override the spread of the generated path.
   - `moveSpeed (number):` Speed of mouse movement.
-
+  - `showTimestamps (boolean):` Generate timestamps for each point based on the trapezoidal rule.
 
 ## How does it work
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import { path } from "ghost-cursor"
 const from = { x: 100, y: 100 }
 const to = { x: 600, y: 700 }
 
-const routes = path(from, to, { showTimestamps: true })
+const route = path(from, to, { showTimestamps: true })
 
 /**
  * [

--- a/src/math.ts
+++ b/src/math.ts
@@ -4,6 +4,9 @@ export interface Vector {
   x: number
   y: number
 }
+export interface TimedVector extends Vector {
+  timestamp: number
+}
 export const origin: Vector = { x: 0, y: 0 }
 
 // maybe i should've just imported a vector library lol
@@ -80,4 +83,16 @@ export const bezierCurve = (
     overrideSpread ?? spread
   )
   return new Bezier(start, ...anchors, finish)
+}
+
+export const bezierCurveSpeed = (
+  t: number,
+  P0: Vector,
+  P1: Vector,
+  P2: Vector,
+  P3: Vector
+): number => {
+  const B1 = 3 * (1 - t) ** 2 * (P1.x - P0.x) + 6 * (1 - t) * t * (P2.x - P1.x) + 3 * t ** 2 * (P3.x - P2.x)
+  const B2 = 3 * (1 - t) ** 2 * (P1.y - P0.y) + 6 * (1 - t) * t * (P2.y - P1.y) + 3 * t ** 2 * (P3.y - P2.y)
+  return Math.sqrt(B1 ** 2 + B2 ** 2)
 }

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -81,7 +81,7 @@ export interface PathOptions {
      * Default is random.
      */
   readonly moveSpeed?: number
-  readonly showTimestamps?: boolean
+  readonly useTimestamps?: boolean
 }
 
 export interface RandomMoveOptions extends Pick<MoveOptions, 'moveDelay' | 'randomizeMoveDelay' | 'moveSpeed'> {
@@ -248,7 +248,7 @@ const clampPositive = (vectors: Vector[], options?: PathOptions): Vector[] | Tim
     y: Math.max(0, vector.y)
   }))
 
-  return options?.showTimestamps === false ? clampedVectors : generateTimestamps(clampedVectors, options)
+  return options?.useTimestamps === true ? generateTimestamps(clampedVectors, options) : clampedVectors
 }
 
 const generateTimestamps = (vectors: Vector[], options?: PathOptions): TimedVector[] => {
@@ -266,12 +266,7 @@ const generateTimestamps = (vectors: Vector[], options?: PathOptions): TimedVect
     return Math.round(total / speed)
   }
 
-  const timedVectors = vectors.map((vector) => {
-    return {
-      ...vector,
-      timestamp: 0
-    }
-  })
+  const timedVectors: TimedVector[] = vectors.map((vector) => ({ ...vector, timestamp: 0 }))
 
   for (let i = 0; i < timedVectors.length; i++) {
     const P0 = i === 0 ? timedVectors[i] : timedVectors[i - 1]
@@ -282,7 +277,7 @@ const generateTimestamps = (vectors: Vector[], options?: PathOptions): TimedVect
 
     timedVectors[i] = {
       ...timedVectors[i],
-      timestamp: i === 0 ? Date.now() : (timedVectors[i - 1] as TimedVector).timestamp + time
+      timestamp: i === 0 ? Date.now() : timedVectors[i - 1].timestamp + time
     }
   }
 

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -1,4 +1,4 @@
-import { ElementHandle, Page, BoundingBox, CDPSession } from 'puppeteer'
+import { ElementHandle, Page, BoundingBox, CDPSession, Protocol } from 'puppeteer'
 import debug from 'debug'
 import {
   Vector,

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -16,82 +16,85 @@ const log = debug('ghost-cursor')
 
 export interface BoxOptions {
   /**
-   * Percentage of padding to be added around the element.
-   * @default 0
-   */
+     * Percentage of padding to be added inside the element.
+     * Example:
+     * - `0` = may be anywhere within the element.
+     * - `100` = will always be center of element.
+     * @default 0
+     */
   readonly paddingPercentage?: number
 }
 
 export interface MoveOptions extends BoxOptions, Pick<PathOptions, 'moveSpeed'> {
   /**
-   * Time to wait for the selector to appear in milliseconds.
-   * Default is to not wait for selector.
-   */
+     * Time to wait for the selector to appear in milliseconds.
+     * Default is to not wait for selector.
+     */
   readonly waitForSelector?: number
   /**
-   * Delay after moving the mouse in milliseconds. If `randomizeMoveDelay=true`, delay is randomized from 0 to `moveDelay`.
-   * @default 0
-   */
+     * Delay after moving the mouse in milliseconds. If `randomizeMoveDelay=true`, delay is randomized from 0 to `moveDelay`.
+     * @default 0
+     */
   readonly moveDelay?: number
   /**
-   * Randomize delay between actions from `0` to `moveDelay`. See `moveDelay` docs.
-   * @default true
-   */
+     * Randomize delay between actions from `0` to `moveDelay`. See `moveDelay` docs.
+     * @default true
+     */
   readonly randomizeMoveDelay?: boolean
   /**
-   * Maximum number of attempts to mouse-over the element.
-   * @default 10
-   */
+     * Maximum number of attempts to mouse-over the element.
+     * @default 10
+     */
   readonly maxTries?: number
   /**
-   * Distance from current location to destination that triggers overshoot to
-   * occur. (Below this distance, no overshoot will occur).
-   * @default 500
-   */
+     * Distance from current location to destination that triggers overshoot to
+     * occur. (Below this distance, no overshoot will occur).
+     * @default 500
+     */
   readonly overshootThreshold?: number
 }
 
 export interface ClickOptions extends MoveOptions {
   /**
-   * Delay before initiating the click action in milliseconds.
-   * @default 0
-   */
+     * Delay before initiating the click action in milliseconds.
+     * @default 0
+     */
   readonly hesitate?: number
   /**
-   * Delay between mousedown and mouseup in milliseconds.
-   * @default 0
-   */
+     * Delay between mousedown and mouseup in milliseconds.
+     * @default 0
+     */
   readonly waitForClick?: number
   /**
-   * @default 2000
-   */
+     * @default 2000
+     */
   readonly moveDelay?: number
 }
 
 export interface PathOptions {
   /**
-   * Override the spread of the generated path.
-   */
+     * Override the spread of the generated path.
+     */
   readonly spreadOverride?: number
   /**
-   * Speed of mouse movement.
-   * Default is random.
-   */
+     * Speed of mouse movement.
+     * Default is random.
+     */
   readonly moveSpeed?: number
   readonly showTimestamps?: boolean
 }
 
 export interface RandomMoveOptions extends Pick<MoveOptions, 'moveDelay' | 'randomizeMoveDelay' | 'moveSpeed'> {
   /**
-   * @default 2000
-   */
+     * @default 2000
+     */
   readonly moveDelay?: number
 }
 
 export interface MoveToOptions extends PathOptions, Pick<MoveOptions, 'moveDelay' | 'randomizeMoveDelay'> {
   /**
-   * @default 0
-   */
+     * @default 0
+     */
   readonly moveDelay?: number
 }
 
@@ -109,7 +112,7 @@ export interface GhostCursor {
   getLocation: () => Vector
 }
 
-// Helper function to wait a specified number of milliseconds
+/** Helper function to wait a specified number of milliseconds  */
 const delay = async (ms: number): Promise<void> => {
   if (ms < 1) return
   return await new Promise((resolve) => setTimeout(resolve, ms))
@@ -127,7 +130,7 @@ const fitts = (distance: number, width: number): number => {
   return a + b * id
 }
 
-// Get a random point on a box
+/** Get a random point on a box */
 const getRandomBoxPoint = (
   { x, y, width, height }: BoundingBox,
   options?: BoxOptions
@@ -137,8 +140,8 @@ const getRandomBoxPoint = (
 
   if (
     options?.paddingPercentage !== undefined &&
-    options?.paddingPercentage > 0 &&
-    options?.paddingPercentage < 100
+        options?.paddingPercentage > 0 &&
+        options?.paddingPercentage <= 100
   ) {
     paddingWidth = (width * options.paddingPercentage) / 100
     paddingHeight = (height * options.paddingPercentage) / 100
@@ -150,10 +153,10 @@ const getRandomBoxPoint = (
   }
 }
 
-// The function signature to access the internal CDP client changed in puppeteer 14.4.1
+/** The function signature to access the internal CDP client changed in puppeteer 14.4.1 */
 const getCDPClient = (page: any): CDPSession => typeof page._client === 'function' ? page._client() : page._client
 
-// Get a random point on a browser window
+/** Get a random point on a browser window */
 export const getRandomPagePoint = async (page: Page): Promise<Vector> => {
   const targetId: string = (page.target() as any)._targetId
   const window = await getCDPClient(page).send(
@@ -168,7 +171,7 @@ export const getRandomPagePoint = async (page: Page): Promise<Vector> => {
   })
 }
 
-// Using this method to get correct position of Inline elements (elements like <a>)
+/** Using this method to get correct position of Inline elements (elements like `<a>`) */
 const getElementBox = async (
   page: Page,
   element: ElementHandle,
@@ -192,9 +195,9 @@ const getElementBox = async (
     if (!relativeToMainFrame) {
       const elementFrame = await element.contentFrame()
       const iframes =
-        elementFrame != null
-          ? await elementFrame.parentFrame()?.$$('xpath/.//iframe')
-          : null
+                elementFrame != null
+                  ? await elementFrame.parentFrame()?.$$('xpath/.//iframe')
+                  : null
       let frame: ElementHandle<Node> | undefined
       if (iframes != null) {
         for (const iframe of iframes) {
@@ -204,9 +207,9 @@ const getElementBox = async (
       if (frame != null) {
         const boundingBox = await frame.boundingBox()
         elementBox.x =
-          boundingBox !== null ? elementBox.x - boundingBox.x : elementBox.x
+                    boundingBox !== null ? elementBox.x - boundingBox.x : elementBox.x
         elementBox.y =
-          boundingBox !== null ? elementBox.y - boundingBox.y : elementBox.y
+                    boundingBox !== null ? elementBox.y - boundingBox.y : elementBox.y
       }
     }
 
@@ -292,9 +295,9 @@ const shouldOvershoot = (a: Vector, b: Vector, threshold: number): boolean =>
 const intersectsElement = (vec: Vector, box: BoundingBox): boolean => {
   return (
     vec.x > box.x &&
-    vec.x <= box.x + box.width &&
-    vec.y > box.y &&
-    vec.y <= box.y + box.height
+        vec.x <= box.x + box.width &&
+        vec.y > box.y &&
+        vec.y <= box.y + box.height
   )
 }
 
@@ -315,42 +318,42 @@ const boundingBoxWithFallback = async (
 export const createCursor = (
   page: Page,
   /**
-   * Cursor start position.
-   * @default { x: 0, y: 0 }
-   */
+     * Cursor start position.
+     * @default { x: 0, y: 0 }
+     */
   start: Vector = origin,
   /**
-   * Initially perform random movements.
-   * If `move`,`click`, etc. is performed, these random movements end.
-   * @default false
-   */
+     * Initially perform random movements.
+     * If `move`,`click`, etc. is performed, these random movements end.
+     * @default false
+     */
   performRandomMoves: boolean = false,
   defaultOptions: {
     /**
-     * Default options for the `randomMove` function that occurs when `performRandomMoves=true`
-     * @default RandomMoveOptions
-     */
+         * Default options for the `randomMove` function that occurs when `performRandomMoves=true`
+         * @default RandomMoveOptions
+         */
     randomMove?: RandomMoveOptions
     /**
-     * Default options for the `move` function
-     * @default MoveOptions
-     */
+         * Default options for the `move` function
+         * @default MoveOptions
+         */
     move?: MoveOptions
     /**
-     * Default options for the `moveTo` function
-     * @default MoveToOptions
-     */
+         * Default options for the `moveTo` function
+         * @default MoveToOptions
+         */
     moveTo?: MoveToOptions
     /**
-     * Default options for the `click` function
-     * @default ClickOptions
-     */
+         * Default options for the `click` function
+         * @default ClickOptions
+         */
     click?: ClickOptions
   } = {}
 ): GhostCursor => {
   // this is kind of arbitrary, not a big fan but it seems to work
-  const overshootSpread = 10
-  const overshootRadius = 120
+  const OVERSHOOT_SPREAD = 10
+  const OVERSHOOT_RADIUS = 120
   let previous: Vector = start
 
   // Initial state: mouse is not moving
@@ -358,7 +361,7 @@ export const createCursor = (
 
   // Move the mouse over a number of vectors
   const tracePath = async (
-    vectors: Iterable<Vector>,
+    vectors: Iterable<Vector | TimedVector>,
     abortOnMove: boolean = false
   ): Promise<void> => {
     const cdpClient = getCDPClient(page)
@@ -406,8 +409,8 @@ export const createCursor = (
       }
       await delay(optionsResolved.moveDelay * (optionsResolved.randomizeMoveDelay ? Math.random() : 1))
       randomMove(options).then(
-        (_) => {},
-        (_) => {}
+        (_) => { },
+        (_) => { }
       ) // fire and forget, recursive function
     } catch (_) {
       log('Warning: stopping random mouse movements')
@@ -503,7 +506,7 @@ export const createCursor = (
           }
           if (elem === null) {
             throw new Error(
-              `Could not find element with selector "${selector}", make sure you're waiting for the elements by specifying "waitForSelector"`
+                            `Could not find element with selector "${selector}", make sure you're waiting for the elements by specifying "waitForSelector"`
             )
           }
         } else {
@@ -535,7 +538,7 @@ export const createCursor = (
           optionsResolved.overshootThreshold
         )
         const to = overshooting
-          ? overshoot(destination, overshootRadius)
+          ? overshoot(destination, OVERSHOOT_RADIUS)
           : destination
 
         await tracePath(path(previous, to, optionsResolved))
@@ -543,7 +546,7 @@ export const createCursor = (
         if (overshooting) {
           const correction = path(to, { ...dimensions, ...destination }, {
             ...optionsResolved,
-            spreadOverride: overshootSpread
+            spreadOverride: OVERSHOOT_SPREAD
           })
 
           await tracePath(correction)
@@ -589,8 +592,8 @@ export const createCursor = (
   // Start random mouse movements. Do not await the promise but return immediately
   if (performRandomMoves) {
     randomMove().then(
-      (_) => {},
-      (_) => {}
+      (_) => { },
+      (_) => { }
     )
   }
 

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -16,85 +16,89 @@ const log = debug('ghost-cursor')
 
 export interface BoxOptions {
   /**
-     * Percentage of padding to be added inside the element.
-     * Example:
-     * - `0` = may be anywhere within the element.
-     * - `100` = will always be center of element.
-     * @default 0
-     */
+   * Percentage of padding to be added inside the element.
+   * Example:
+   * - `0` = may be anywhere within the element.
+   * - `100` = will always be center of element.
+   * @default 0
+   */
   readonly paddingPercentage?: number
 }
 
 export interface MoveOptions extends BoxOptions, Pick<PathOptions, 'moveSpeed'> {
   /**
-     * Time to wait for the selector to appear in milliseconds.
-     * Default is to not wait for selector.
-     */
+   * Time to wait for the selector to appear in milliseconds.
+   * Default is to not wait for selector.
+   */
   readonly waitForSelector?: number
   /**
-     * Delay after moving the mouse in milliseconds. If `randomizeMoveDelay=true`, delay is randomized from 0 to `moveDelay`.
-     * @default 0
-     */
+   * Delay after moving the mouse in milliseconds. If `randomizeMoveDelay=true`, delay is randomized from 0 to `moveDelay`.
+   * @default 0
+   */
   readonly moveDelay?: number
   /**
-     * Randomize delay between actions from `0` to `moveDelay`. See `moveDelay` docs.
-     * @default true
-     */
+   * Randomize delay between actions from `0` to `moveDelay`. See `moveDelay` docs.
+   * @default true
+   */
   readonly randomizeMoveDelay?: boolean
   /**
-     * Maximum number of attempts to mouse-over the element.
-     * @default 10
-     */
+   * Maximum number of attempts to mouse-over the element.
+   * @default 10
+   */
   readonly maxTries?: number
   /**
-     * Distance from current location to destination that triggers overshoot to
-     * occur. (Below this distance, no overshoot will occur).
-     * @default 500
-     */
+   * Distance from current location to destination that triggers overshoot to
+   * occur. (Below this distance, no overshoot will occur).
+   * @default 500
+   */
   readonly overshootThreshold?: number
 }
 
 export interface ClickOptions extends MoveOptions {
   /**
-     * Delay before initiating the click action in milliseconds.
-     * @default 0
-     */
+   * Delay before initiating the click action in milliseconds.
+   * @default 0
+   */
   readonly hesitate?: number
   /**
-     * Delay between mousedown and mouseup in milliseconds.
-     * @default 0
-     */
+   * Delay between mousedown and mouseup in milliseconds.
+   * @default 0
+   */
   readonly waitForClick?: number
   /**
-     * @default 2000
-     */
+   * @default 2000
+   */
   readonly moveDelay?: number
 }
 
 export interface PathOptions {
   /**
-     * Override the spread of the generated path.
-     */
+   * Override the spread of the generated path.
+   */
   readonly spreadOverride?: number
   /**
-     * Speed of mouse movement.
-     * Default is random.
-     */
+   * Speed of mouse movement.
+   * Default is random.
+   */
   readonly moveSpeed?: number
+
+  /**
+   * Generate timestamps for each point in the path.
+   */
   readonly useTimestamps?: boolean
 }
 
 export interface RandomMoveOptions extends Pick<MoveOptions, 'moveDelay' | 'randomizeMoveDelay' | 'moveSpeed'> {
   /**
-     * @default 2000
-     */
+   * @default 2000
+   */
   readonly moveDelay?: number
 }
 
 export interface MoveToOptions extends PathOptions, Pick<MoveOptions, 'moveDelay' | 'randomizeMoveDelay'> {
   /**
-     * @default 0
-     */
+   * @default 0
+   */
   readonly moveDelay?: number
 }
 
@@ -140,8 +144,8 @@ const getRandomBoxPoint = (
 
   if (
     options?.paddingPercentage !== undefined &&
-        options?.paddingPercentage > 0 &&
-        options?.paddingPercentage <= 100
+    options?.paddingPercentage > 0 &&
+    options?.paddingPercentage <= 100
   ) {
     paddingWidth = (width * options.paddingPercentage) / 100
     paddingHeight = (height * options.paddingPercentage) / 100
@@ -195,9 +199,9 @@ const getElementBox = async (
     if (!relativeToMainFrame) {
       const elementFrame = await element.contentFrame()
       const iframes =
-                elementFrame != null
-                  ? await elementFrame.parentFrame()?.$$('xpath/.//iframe')
-                  : null
+        elementFrame != null
+          ? await elementFrame.parentFrame()?.$$('xpath/.//iframe')
+          : null
       let frame: ElementHandle<Node> | undefined
       if (iframes != null) {
         for (const iframe of iframes) {
@@ -207,9 +211,9 @@ const getElementBox = async (
       if (frame != null) {
         const boundingBox = await frame.boundingBox()
         elementBox.x =
-                    boundingBox !== null ? elementBox.x - boundingBox.x : elementBox.x
+          boundingBox !== null ? elementBox.x - boundingBox.x : elementBox.x
         elementBox.y =
-                    boundingBox !== null ? elementBox.y - boundingBox.y : elementBox.y
+          boundingBox !== null ? elementBox.y - boundingBox.y : elementBox.y
       }
     }
 
@@ -290,9 +294,9 @@ const shouldOvershoot = (a: Vector, b: Vector, threshold: number): boolean =>
 const intersectsElement = (vec: Vector, box: BoundingBox): boolean => {
   return (
     vec.x > box.x &&
-        vec.x <= box.x + box.width &&
-        vec.y > box.y &&
-        vec.y <= box.y + box.height
+    vec.x <= box.x + box.width &&
+    vec.y > box.y &&
+    vec.y <= box.y + box.height
   )
 }
 
@@ -313,36 +317,36 @@ const boundingBoxWithFallback = async (
 export const createCursor = (
   page: Page,
   /**
-     * Cursor start position.
-     * @default { x: 0, y: 0 }
-     */
+   * Cursor start position.
+   * @default { x: 0, y: 0 }
+   */
   start: Vector = origin,
   /**
-     * Initially perform random movements.
-     * If `move`,`click`, etc. is performed, these random movements end.
-     * @default false
-     */
+   * Initially perform random movements.
+   * If `move`,`click`, etc. is performed, these random movements end.
+   * @default false
+   */
   performRandomMoves: boolean = false,
   defaultOptions: {
     /**
-         * Default options for the `randomMove` function that occurs when `performRandomMoves=true`
-         * @default RandomMoveOptions
-         */
+     * Default options for the `randomMove` function that occurs when `performRandomMoves=true`
+     * @default RandomMoveOptions
+     */
     randomMove?: RandomMoveOptions
     /**
-         * Default options for the `move` function
-         * @default MoveOptions
-         */
+     * Default options for the `move` function
+     * @default MoveOptions
+     */
     move?: MoveOptions
     /**
-         * Default options for the `moveTo` function
-         * @default MoveToOptions
-         */
+     * Default options for the `moveTo` function
+     * @default MoveToOptions
+     */
     moveTo?: MoveToOptions
     /**
-         * Default options for the `click` function
-         * @default ClickOptions
-         */
+     * Default options for the `click` function
+     * @default ClickOptions
+     */
     click?: ClickOptions
   } = {}
 ): GhostCursor => {
@@ -404,8 +408,8 @@ export const createCursor = (
       }
       await delay(optionsResolved.moveDelay * (optionsResolved.randomizeMoveDelay ? Math.random() : 1))
       randomMove(options).then(
-        (_) => { },
-        (_) => { }
+        (_) => {},
+        (_) => {}
       ) // fire and forget, recursive function
     } catch (_) {
       log('Warning: stopping random mouse movements')
@@ -501,7 +505,7 @@ export const createCursor = (
           }
           if (elem === null) {
             throw new Error(
-                            `Could not find element with selector "${selector}", make sure you're waiting for the elements by specifying "waitForSelector"`
+              `Could not find element with selector "${selector}", make sure you're waiting for the elements by specifying "waitForSelector"`
             )
           }
         } else {
@@ -587,8 +591,8 @@ export const createCursor = (
   // Start random mouse movements. Do not await the promise but return immediately
   if (performRandomMoves) {
     randomMove().then(
-      (_) => { },
-      (_) => { }
+      (_) => {},
+      (_) => {}
     )
   }
 


### PR DESCRIPTION
Take two on a PR I did a few years ago (https://github.com/Xetera/ghost-cursor/pull/42).

This version does _essentially_ the same thing as the original PR but with a more elegant approach by utilizing the options that can be passed to the path function and calculating the time to take using the [Trapezoidal rule](https://en.wikipedia.org/wiki/Trapezoidal_rule).

I'm open to any suggestions/changes so please let me know.