### PR TITLE
fix: move applies moveDelay

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Moves the mouse to the specified selector or element.
 - **options (optional):** Additional options for moving.
   - `paddingPercentage (number):` Percentage of padding to be added around the element. Default is `0`.
   - `waitForSelector (number):` Time to wait for the selector to appear in milliseconds. Default is to not wait for selector.
-  - `moveDelay (number):` Delay after moving the mouse in milliseconds. Default is `2000`.
+  - `moveDelay (number):` Delay after moving the mouse in milliseconds. Default is `0`.
   - `maxTries (number):` Maximum number of attempts to mouse-over the element. Default is `10`.
   - `moveSpeed (number):` Speed of mouse movement. Default is random.
 

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -287,11 +287,13 @@ export const createCursor = (
         }), true)
         previous = rand
       }
-      if (options?.moveDelay !== undefined && options.moveDelay >= 0) {
-        await delay(Math.random() * options.moveDelay)
-      } else {
-        await delay(Math.random() * 2000) // 2s by default
-      }
+
+      const moveDelay =
+        options?.moveDelay !== undefined && options?.moveDelay >= 0
+          ? options.moveDelay
+          : 2000 // 2s by default
+      await delay(Math.random() * moveDelay)
+
       randomMove().then(
         (_) => {},
         (_) => {}
@@ -313,7 +315,11 @@ export const createCursor = (
       actions.toggleRandomMove(false)
 
       if (selector !== undefined) {
-        await actions.move(selector, options)
+        await actions.move(selector, {
+          ...options,
+          // apply moveDelay after click, but not after actual move
+          moveDelay: 0
+        })
         actions.toggleRandomMove(false)
       }
 
@@ -330,11 +336,11 @@ export const createCursor = (
         log('Warning: could not click mouse, error message:', error)
       }
 
-      if (options?.moveDelay !== undefined && options.moveDelay >= 0) {
-        await delay(Math.random() * options.moveDelay)
-      } else {
-        await delay(Math.random() * 2000) // 2s by default
-      }
+      const moveDelay =
+        options?.moveDelay !== undefined && options?.moveDelay >= 0
+          ? options.moveDelay
+          : 2000 // 2s by default
+      await delay(Math.random() * moveDelay)
 
       actions.toggleRandomMove(true)
     },
@@ -426,7 +432,13 @@ export const createCursor = (
           return await go(iteration + 1)
         }
       }
-      return await go(0)
+      await go(0)
+
+      const moveDelay =
+      options?.moveDelay !== undefined && options?.moveDelay >= 0
+        ? options.moveDelay
+        : 2000 // 2s by default
+      await delay(Math.random() * moveDelay)
     },
     async moveTo (destination: Vector): Promise<void> {
       actions.toggleRandomMove(false)

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -287,9 +287,7 @@ export const createCursor = (
     try {
       if (!moving) {
         const rand = await getRandomPagePoint(page)
-        await tracePath(path(previous, rand, {
-          moveSpeed: options?.moveSpeed
-        }), true)
+        await tracePath(path(previous, rand, options), true)
         previous = rand
       }
 

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -28,7 +28,7 @@ export interface MoveOptions extends BoxOptions {
   readonly waitForSelector?: number
   /**
    * Delay after moving the mouse in milliseconds.
-   * @default 2000
+   * @default 0
    */
   readonly moveDelay?: number
   /**
@@ -54,6 +54,11 @@ export interface ClickOptions extends MoveOptions {
    * @default 0
    */
   readonly waitForClick?: number
+  /**
+   * Delay after performing the click in milliseconds.
+   * @default 2000
+   */
+  readonly moveDelay?: number
 }
 
 export interface PathOptions {
@@ -437,7 +442,7 @@ export const createCursor = (
       const moveDelay =
       options?.moveDelay !== undefined && options?.moveDelay >= 0
         ? options.moveDelay
-        : 2000 // 2s by default
+        : 0 // No move delay by default
       await delay(Math.random() * moveDelay)
     },
     async moveTo (destination: Vector): Promise<void> {

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -287,7 +287,9 @@ export const createCursor = (
     try {
       if (!moving) {
         const rand = await getRandomPagePoint(page)
-        await tracePath(path(previous, rand, options), true)
+        await tracePath(path(previous, rand, {
+          moveSpeed: options?.moveSpeed
+        }), true)
         previous = rand
       }
 


### PR DESCRIPTION
`moveDelay` option in `move` function had no effect. Implement it.

Other option would be to omit `moveDelay` from `move` `options`