### PR TITLE
refactor: move path function to tracePath, rename to moveMouse

### DIFF
--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -602,13 +602,12 @@ export const createCursor = (
       } satisfies MoveOptions
 
       const wasRandom = !moving
+      actions.toggleRandomMove(false)
 
       const go = async (iteration: number): Promise<void> => {
         if (iteration > (optionsResolved.maxTries)) {
           throw Error('Could not mouse-over element within enough tries')
         }
-
-        actions.toggleRandomMove(false)
 
         const elem = await this.getElement(selector, optionsResolved)
 
@@ -636,8 +635,6 @@ export const createCursor = (
           // go directly to the box, no overshoot
           await moveMouse(destination, optionsResolved)
         }
-
-        actions.toggleRandomMove(true)
 
         const newBoundingBox = await getElementBox(page, elem)
 

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -355,9 +355,9 @@ export function path (
   end: Vector | BoundingBox,
   /**
    * Additional options for generating the path.
-   * Can also be a number which will set `spreadOverride` (TODO: remove this in next major version change,
-   * no need to not just allow object.)
+   * Can also be a number which will set `spreadOverride`.
    */
+  // TODO: remove number arg in next major version change, fine to just allow `spreadOverride` in object.
   options?: number | PathOptions): Vector[] | TimedVector[] {
   const optionsResolved: PathOptions = typeof options === 'number'
     ? { spreadOverride: options }

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -467,9 +467,9 @@ export const createCursor = (
   // Initial state: mouse is not moving
   let moving: boolean = false
 
-  /** Move the mouse over a number of vectors */
+  /** Move the mouse to a point, getting the vectors via `path(previous, newLocation, options)`  */
   const moveMouse = async (
-    newLocation: BoundingBox | Vector,
+    newLocation: Vector | BoundingBox,
     options?: PathOptions,
     abortOnMove: boolean = false
   ): Promise<void> => {

--- a/src/spoof.ts
+++ b/src/spoof.ts
@@ -202,32 +202,39 @@ export interface GhostCursor {
   /** Simulates a mouse click at the specified selector or element. */
   click: (
     selector?: string | ElementHandle,
+    /** @default defaultOptions.click */
     options?: ClickOptions
   ) => Promise<void>
   /** Moves the mouse to the specified selector or element. */
   move: (
     selector: string | ElementHandle,
+    /** @default defaultOptions.move */
     options?: MoveOptions
   ) => Promise<void>
   /** Moves the mouse to the specified destination point. */
   moveTo: (
     destination: Vector,
+    /** @default defaultOptions.moveTo */
     options?: MoveToOptions) => Promise<void>
   /** Scrolls the element into view. If already in view, no scroll occurs. */
   scrollIntoView: (
     selector: ElementHandle,
+    /** @default defaultOptions.scroll */
     options?: ScrollIntoViewOptions) => Promise<void>
   /** Scrolls to the specified destination point. */
   scrollTo: (
     destination: ScrollToDestination,
+    /** @default defaultOptions.scroll */
     options?: ScrollOptions) => Promise<void>
   /** Scrolls the page the distance set by `delta`. */
   scroll: (
     delta: Partial<Vector>,
+    /** @default defaultOptions.scroll */
     options?: ScrollOptions) => Promise<void>
   /** Gets the element via a selector. Can use an XPath. */
   getElement: (
     selector: string | ElementHandle,
+    /** @default defaultOptions.getElement */
     options?: GetElementOptions) => Promise<ElementHandle<Element>>
   /** Get current location of the cursor. */
   getLocation: () => Vector


### PR DESCRIPTION
Basically just realized every usage of `tracePath` was `tracePath(path(previous ...` , so put this into the `tracePath` function. Because the argument no longer a path of vectors, renamed it to `moveMouse`.